### PR TITLE
Fix: Dialog Hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@suankularb-components/css",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suankularb-components/css",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A design system for all Suankularb applications",
   "module": "dist\\js\\suankularb-components.esm.js",
   "browser": "dist\\js\\suankularb-components.umd.min.js",

--- a/src/scss/components/Button.scss
+++ b/src/scss/components/Button.scss
@@ -145,7 +145,8 @@
 .btn--tonal.btn--icon {
   display: grid;
   place-content: center;
-  width: 2.5rem;
+  height: 2.75rem;
+  padding: 0;
   aspect-ratio: 1 / 1;
 }
 

--- a/src/scss/components/Button.scss
+++ b/src/scss/components/Button.scss
@@ -139,8 +139,17 @@
   }
 }
 
-// Icon button
-.btn--icon {
+// Icon Button
+.btn--filled.btn--icon,
+.btn--outlined.btn--icon,
+.btn--tonal.btn--icon {
+  display: grid;
+  place-content: center;
+  width: 2.5rem;
+  aspect-ratio: 1 / 1;
+}
+
+.btn--text.btn--icon {
   padding: 0;
   overflow: visible;
 

--- a/src/scss/components/Button.scss
+++ b/src/scss/components/Button.scss
@@ -6,6 +6,7 @@
   font-weight: var(--font-medium);
   font-family: var(--font-display);
   text-align: center;
+  white-space: nowrap;
   border-radius: 9999px;
   overflow: hidden;
   outline: none;

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -179,9 +179,30 @@
 
   .dialog__header,
   .dialog__hero,
-  .dialog__section,
-  .dialog__list {
+  .dialog__section {
     padding: 1rem;
+  }
+
+  .dialog__hero {
+    align-items: flex-start;
+    flex-grow: 1;
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      text-align: left;
+    }
+
+    .dialog__hero-icon {
+      display: none;
+    }
+  }
+
+  .dialog__list {
+    padding: 0;
   }
 
   // Remove the bottom actions
@@ -237,9 +258,25 @@
 
     .dialog__header,
     .dialog__hero,
-    .dialog__section,
-    .dialog__list {
+    .dialog__section {
       padding: 1.5rem;
+    }
+
+    .dialog__hero {
+      align-items: center;
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        text-align: center;
+      }
+
+      .dialog__hero-icon {
+        display: block;
+      }
     }
 
     .dialog__actions {

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -178,7 +178,6 @@
   overflow: hidden auto;
 
   .dialog__header,
-  .dialog__hero,
   .dialog__section {
     padding: 1rem;
   }
@@ -252,7 +251,6 @@
     // Resets changes made by the Fullscreen Dialog
 
     .dialog__header,
-    .dialog__hero,
     .dialog__section {
       padding: 1.5rem;
     }

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -218,11 +218,6 @@
     align-items: center;
     gap: 1rem;
 
-    .dialog__top-app-bar__close {
-      width: 2.5rem;
-      aspect-ratio: 1 / 1;
-    }
-
     button {
       display: block;
     }

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -43,6 +43,7 @@
 
 // Dialog
 .dialog {
+  @include us.scroll-w(0);
   display: flex;
   flex-direction: column;
   padding: 0;
@@ -57,11 +58,6 @@
   transition: opacity var(--animation-speed) var(--animation-timing),
     transform var(--animation-speed) var(--animation-timing);
   overflow: auto;
-
-  &::-webkit-scrollbar {
-    width: 0;
-    height: 0;
-  }
 }
 
 .dialog__header {

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -269,6 +269,7 @@
 
       .dialog__hero-icon {
         display: block;
+        color: var(--secondary);
       }
     }
 

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -183,8 +183,10 @@
   }
 
   .dialog__hero {
+    @include us.scroll-w(0);
     align-items: flex-start;
     flex-grow: 1;
+    overflow-x: auto;
 
     h1,
     h2,
@@ -193,6 +195,7 @@
     h5,
     h6 {
       text-align: left;
+      width: max-content;
     }
 
     .dialog__hero-icon {

--- a/src/scss/components/Icon.scss
+++ b/src/scss/components/Icon.scss
@@ -1,5 +1,5 @@
 .icon {
-  display: inline-block;
+  display: block;
   width: 1em;
   font-style: normal;
   font-weight: normal;
@@ -14,6 +14,10 @@
   direction: ltr;
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
+
+  &--inline {
+    display: inline;
+  }
 
   &--custom-size {
     font-size: inherit;

--- a/src/scss/components/input/Dropdown.scss
+++ b/src/scss/components/input/Dropdown.scss
@@ -82,6 +82,7 @@
   box-shadow: var(--shadow-1);
   border-radius: 0 0 var(--rounded-sm) var(--rounded-sm);
   padding: 0.25rem 0;
+  z-index: 1;
 
   a,
   button {

--- a/src/scss/utils/_all.scss
+++ b/src/scss/utils/_all.scss
@@ -2,4 +2,5 @@
 @use "has-action";
 @use "layout-grid";
 @use "max-lines";
+@use "scrollbar";
 @use "shadow";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26425747/158730994-7633ea6e-0a74-429c-93d5-c04c8ce37928.png)

**Features**
* Icon Button for Filled, Outlined, and Tonal Buttons (formerly only available for Text Button)
* Dialog Hero can now be used in Large Dialog

**Fixes**
* Icons have unpredictable behaviours
  (may be fixed by putting on `display: block;` but remains to be seen)
* Text inside button can go on >1 lines
* Padding on Dialog Hero and Dialog List is wrong
* Dropdown Options is not always in front
* https://github.com/suankularb-wittayalai-school/sk-components/issues/30

**Refs**
Fixes #30