### PR TITLE
Fix: Dialog Padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@suankularb-components/css",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suankularb-components/css",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A design system for all Suankularb applications",
   "module": "dist\\js\\suankularb-components.esm.js",
   "browser": "dist\\js\\suankularb-components.umd.min.js",

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -19,6 +19,15 @@
     opacity: 1;
     pointer-events: auto;
   }
+
+  &--no-transition {
+    @extend .dialog__wrapper;
+    transition: none;
+
+    .dialog, .dialog--large {
+      transition: none;
+    }
+  }
 }
 
 // Overlay

--- a/src/scss/components/Dialog.scss
+++ b/src/scss/components/Dialog.scss
@@ -24,7 +24,8 @@
     @extend .dialog__wrapper;
     transition: none;
 
-    .dialog, .dialog--large {
+    .dialog,
+    .dialog--large {
       transition: none;
     }
   }
@@ -70,11 +71,17 @@
   overflow: auto;
 }
 
+.dialog__content {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.5rem 0;
+  gap: 1rem;
+}
+
 .dialog__header {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1.5rem 1.5rem 0.5rem;
 
   h1,
   h2,
@@ -110,8 +117,6 @@
   flex-direction: column;
   gap: 1rem;
 
-  padding: 1.5rem;
-
   h1,
   h2,
   h3,
@@ -126,7 +131,7 @@
   .dialog__columns {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 1rem 1.5rem;
+    gap: 0.75rem 1.5rem;
   }
 }
 
@@ -140,7 +145,6 @@
     justify-content: space-between;
     align-items: center;
     gap: 1rem;
-    margin: 0 1.5rem;
     padding: 0.5rem 0;
     height: 3.625rem;
     accent-color: var(--primary);
@@ -184,9 +188,8 @@
     transform var(--animation-speed) var(--animation-timing);
   overflow: hidden auto;
 
-  .dialog__header,
-  .dialog__section {
-    padding: 1rem;
+  .dialog__content {
+    padding: 1rem 1rem 0;
   }
 
   .dialog__hero {
@@ -260,10 +263,8 @@
     background-color: var(--surface-3);
 
     // Resets changes made by the Fullscreen Dialog
-
-    .dialog__header,
-    .dialog__section {
-      padding: 1.5rem;
+    .dialog__content {
+      padding: 1.5rem 1.5rem 0;
     }
 
     .dialog__hero {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26425747/159344151-bd4f2f07-05ed-4878-9554-33210bfe5596.png)

> *Attention, backwards compatibility lost*: Dialog Header, Dialog Section, and Dialog List now need to be wrapped in Dialog Content to work properly

**Features**
* No Transtion modifier for Dialog
* Dialog Content

**Fixes**
* Dialog doesn’t work with [Framer Motion](https://www.framer.com/motion/)
* Dialog has wrong padding