### PR TITLE
Fix: Button Spacing

### DIFF
--- a/src/scss/abstracts/typography.scss
+++ b/src/scss/abstracts/typography.scss
@@ -1,8 +1,3 @@
-// Google Font imports
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700;900&family=Sora:wght@100;200;300;400;500;600;700;800&family=Noto+Sans+Thai:wght@400;500;700;900&display=swap");
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons+Outlined");
-
 :root {
   // Font size
   --text-xs: 0.6875rem;

--- a/src/scss/components/Button.scss
+++ b/src/scss/components/Button.scss
@@ -149,6 +149,10 @@
   &:active::before {
     background-color: var(--primary-translucent-12);
   }
+
+  &.btn--has-icon {
+    padding: 0 0.5rem 0 0.25rem;
+  }
 }
 
 // Icon Button

--- a/src/scss/components/Button.scss
+++ b/src/scss/components/Button.scss
@@ -128,6 +128,11 @@
       background-color: var(--primary-translucent-12);
     }
   }
+
+  &.btn--has-icon {
+    padding: calc(0.625rem - 2px) calc(1.5rem - 2px) calc(0.625rem - 2px)
+      calc(1rem - 2px);
+  }
 }
 
 // Text button


### PR DESCRIPTION
**Fixes**
- Font imports in SKCom conflicts with font imports done by the frontend
- Outlined Button with Icon has too much padding on the left
- Text Button with Icon has too much padding on the left