### PR TITLE
[3.0.4] Fix: Wide Selectors

### DIFF
--- a/apps/demo/components/example/lookup/ContactCard.tsx
+++ b/apps/demo/components/example/lookup/ContactCard.tsx
@@ -39,7 +39,13 @@ const ContactCard: FC<{
   };
 
   return (
-    <Card appearance="outlined" direction="row" stateLayerEffect href={href}>
+    <Card
+      appearance="outlined"
+      direction="row"
+      stateLayerEffect
+      href={href}
+      aAttr={{ target: "_blank", rel: "noreferrer" }}
+    >
       <CardHeader
         avatar={<Avatar>{avatarMap[type]}</Avatar>}
         title={label}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11446,6 +11446,84 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.3.tgz",
+      "integrity": "sha512-mykdVaAXX/gm+eFO2kPeVjnOCKwanJ9mV2U0lsUGLrEdMUifPUjiXKc6qFAIs08PvmTMOLMNnUxqhGsJlWGKSw==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.3.tgz",
+      "integrity": "sha512-8XwHPpA12gdIFtope+n9xCtJZM3U4gH4vVTpUwJ2w1kfxFmCpwQ4xmeGSkR67uOg80yRMuF0h9V1ueo05sws5w==",
+      "optional": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.3.tgz",
+      "integrity": "sha512-TXOubiFdLpMfMtaRu1K5d1I9ipKbW5iS2BNbu8zJhoqrhk3Kp7aRKTxqFfWrbliAHhWVE/3fQZUYZOWSXVQi1w==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.3.tgz",
+      "integrity": "sha512-GZctkN6bJbpjlFiS5pylgB2pifHvgkqLAPumJzxnxkf7kqNm6rOGuNjsROvOWVWXmKhrzQkREO/WPS2aWsr/yw==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.3.tgz",
+      "integrity": "sha512-rK6GpmMt/mU6MPuav0/M7hJ/3t8HbKPCELw/Uqhi4732xoq2hJ2zbo2FkYs56y6w0KiXrIp4IOwNB9K8L/q62g==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.3.tgz",
+      "integrity": "sha512-yeiCp/Odt1UJ4KUE89XkeaaboIDiVFqKP4esvoLKGJ0fcqJXMofj4ad3tuQxAMs3F+qqrz9MclqhAHkex1aPZA==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.3.tgz",
+      "integrity": "sha512-/miIopDOUsuNlvjBjTipvoyjjaxgkOuvlz+cIbbPcm1eFvzX2ltSfgMgty15GuOiR8Hub4FeTSiq3g2dmCkzGA==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.3.tgz",
+      "integrity": "sha512-sujxFDhMMDjqhruup8LLGV/y+nCPi6nm5DlFoThMJFvaaKr/imhkXuk8uCTq4YJDbtRxnjydFv2y8laBSJVC2g==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.3.tgz",
+      "integrity": "sha512-w5MyxPknVvC9LVnMenAYMXMx4KxPwXuJRMQFvY71uXg68n7cvcas85U5zkdrbmuZ+JvsO5SIG8k36/6X3nUhmQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.3.tgz",
+      "integrity": "sha512-CTeelh8OzSOVqpzMFMFnVRJIFAFQoTsI9RmVJWW/92S4xfECGcOzgsX37CZ8K982WHRzKU7exeh7vYdG/Eh4CA==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.3.tgz",
+      "integrity": "sha512-7N1KBQP5mo4xf52cFCHgMjzbc9jizIlkTepe9tMa2WFvEIlKDfdt38QYcr9mbtny17yuaIw02FXOVEytGzqdOQ==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.3.tgz",
+      "integrity": "sha512-LzWD5pTSipUXTEMRjtxES/NBYktuZdo7xExJqGDMnZU8WOI+v9mQzsmQgZS/q02eIv78JOCSemqVVKZBGCgUvA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.3.tgz",
+      "integrity": "sha512-aLG2MaFs4y7IwaMTosz2r4mVbqRyCnMoFqOcmfTi7/mAS+G4IMH0vJp4oLdbshqiVoiVuKrAfqtXj55/m7Qu1Q==",
+      "optional": true
     }
   }
 }

--- a/packages/skcom-css/src/components/chip-field.scss
+++ b/packages/skcom-css/src/components/chip-field.scss
@@ -77,7 +77,7 @@
 }
 
 // Chip Set
-.skc-chip-field .skc-chip-set {
+.skc-chip-field > .skc-chip-set {
   flex-wrap: nowrap;
   padding-block: 0.5rem;
 
@@ -95,7 +95,7 @@
 }
 
 // Linear Progress
-.skc-chip-field .skc-progress {
+.skc-chip-field > .skc-progress {
   position: absolute;
   inset: auto 0 0;
 }

--- a/packages/skcom-css/src/components/chip-field.scss
+++ b/packages/skcom-css/src/components/chip-field.scss
@@ -46,7 +46,6 @@
   }
 }
 
-// Contextual adaptations
 .skc-chip-field__label {
   .skc-dialog & {
     background-color: var(--surface-3);

--- a/packages/skcom-css/src/components/content-layout.scss
+++ b/packages/skcom-css/src/components/content-layout.scss
@@ -19,9 +19,11 @@
   max-width: 70.5rem;
   margin: 0 auto;
 
-  > .skc-section > *,
-  > .skc-columns > .skc-section > * {
-    margin-inline: 1rem;
+  &,
+  > .skc-columns {
+    > .skc-section > *:not(.skc-scrim) {
+      margin-inline: 1rem;
+    }
   }
 }
 
@@ -33,9 +35,11 @@
   .skc-content-layout__content {
     width: calc(100% - (10rem));
 
-    > .skc-section > *,
-    > .skc-columns > .skc-section > * {
-      margin-inline: 0;
+    &,
+    > .skc-columns {
+      > .skc-section > *:not(.skc-scrim) {
+        margin-inline: 0;
+      }
     }
   }
 }

--- a/packages/skcom-css/src/components/dialog.scss
+++ b/packages/skcom-css/src/components/dialog.scss
@@ -22,23 +22,8 @@
   > .skc-actions {
     padding: 1.5rem 1.5rem 1.5rem 1rem;
   }
-
-  &,
-  .skc-text-field--outlined .skc-text-field__label,
-  .skc-chip-field__label {
-    background-color: var(--surface-3);
-  }
-
-  .skc-text-field--filled {
-    background-color: var(--surface-1);
-
-    &::before {
-      background-color: var(--outline);
-    }
-  }
 }
 
 .skc-dialog ~ .skc-scrim {
-  z-index: 90;
   margin: 0 !important;
 }

--- a/packages/skcom-css/src/components/dialog.scss
+++ b/packages/skcom-css/src/components/dialog.scss
@@ -39,5 +39,6 @@
 }
 
 .skc-dialog ~ .skc-scrim {
+  z-index: 90;
   margin: 0 !important;
 }

--- a/packages/skcom-css/src/components/fab.scss
+++ b/packages/skcom-css/src/components/fab.scss
@@ -45,7 +45,7 @@
 }
 
 // Hover effect on state layer
-.skc-fab__wrapper:hover .skc-fab,
+.skc-fab__wrapper:hover > .skc-fab,
 .skc-fab:hover {
   &::before {
     opacity: 0.08;
@@ -53,8 +53,8 @@
 }
 
 // Focus and active effect on state layer
-.skc-fab__wrapper:focus .skc-fab,
-.skc-fab__wrapper:active .skc-fab,
+.skc-fab__wrapper:focus > .skc-fab,
+.skc-fab__wrapper:active > .skc-fab,
 .skc-fab:focus,
 .skc-fab:active {
   &::before {

--- a/packages/skcom-css/src/components/fullscreen-dialog.scss
+++ b/packages/skcom-css/src/components/fullscreen-dialog.scss
@@ -71,6 +71,7 @@
 }
 
 .skc-fullscreen-dialog ~ .skc-scrim {
+  z-index: 90;
   margin: 0 !important;
 }
 

--- a/packages/skcom-css/src/components/fullscreen-dialog.scss
+++ b/packages/skcom-css/src/components/fullscreen-dialog.scss
@@ -71,7 +71,6 @@
 }
 
 .skc-fullscreen-dialog ~ .skc-scrim {
-  z-index: 90;
   margin: 0 !important;
 }
 
@@ -90,20 +89,6 @@
     transform: translate(-50%, -50%);
     border-radius: var(--rounded-xl);
     background-color: var(--surface-3);
-
-    &,
-    .skc-text-field--outlined .skc-text-field__label,
-    .skc-chip-field__label {
-      background-color: var(--surface-3);
-    }
-
-    .skc-text-field--filled {
-      background-color: var(--surface-1);
-
-      &::before {
-        background-color: var(--outline);
-      }
-    }
   }
 
   .skc-fullscreen-dialog__top-app-bar {

--- a/packages/skcom-css/src/components/nav-bar.scss
+++ b/packages/skcom-css/src/components/nav-bar.scss
@@ -18,7 +18,7 @@
   height: 0;
 }
 
-.skc-nav-bar__toggle-and-fab .skc-button,
+.skc-nav-bar__toggle-and-fab > .skc-button,
 .skc-nav-bar__brand,
 .skc-nav-bar__end {
   display: none;

--- a/packages/skcom-css/src/components/nav-drawer.scss
+++ b/packages/skcom-css/src/components/nav-drawer.scss
@@ -6,6 +6,7 @@
 ////
 
 .skc-nav-drawer {
+  z-index: 90;
   display: flex;
   overflow-y: auto;
   flex-direction: column;

--- a/packages/skcom-css/src/components/page-header.scss
+++ b/packages/skcom-css/src/components/page-header.scss
@@ -15,19 +15,6 @@
   padding: 1rem 0 1.75rem;
   background-color: var(--surface-5);
 
-  &,
-  .skc-text-field--outlined .skc-text-field__label {
-    background-color: var(--surface-5);
-  }
-
-  .skc-text-field--filled {
-    background-color: var(--surface-1);
-
-    &::before {
-      background-color: var(--outline);
-    }
-  }
-
   &:has(.skc-page-header__related .skc-tabs-container:last-child) {
     padding-bottom: 0;
   }

--- a/packages/skcom-css/src/components/root-layout.scss
+++ b/packages/skcom-css/src/components/root-layout.scss
@@ -37,7 +37,7 @@ body {
 
 .skc-root-layout > .skc-nav-drawer {
   position: fixed;
-  z-index: 80;
+  z-index: 90;
   top: 0;
   left: 0;
 }
@@ -48,7 +48,7 @@ body {
 
 .skc-scrim {
   position: fixed;
-  z-index: 80;
+  z-index: 90;
   top: 0;
   right: 0;
   bottom: 0;

--- a/packages/skcom-css/src/components/select.scss
+++ b/packages/skcom-css/src/components/select.scss
@@ -95,6 +95,34 @@
   }
 }
 
+// Contextual adaptations
+.skc-dialog,
+.skc-fullscreen-dialog,
+.skc-page-header,
+.skc-card--filled {
+  .skc-select--filled {
+    background-color: var(--surface-1);
+
+    &::before {
+      background-color: var(--outline);
+    }
+  }
+}
+
+.skc-select--outlined .skc-select__label {
+  .skc-dialog & {
+    background-color: var(--surface-3);
+  }
+
+  .skc-page-header & {
+    background-color: var(--surface-5);
+  }
+
+  .skc-card--filled & {
+    background-color: var(--surface-variant);
+  }
+}
+
 // Options Menu
 .skc-select ~ .skc-menu {
   inset: 3.5rem 0 auto 0;

--- a/packages/skcom-css/src/components/split-layout.scss
+++ b/packages/skcom-css/src/components/split-layout.scss
@@ -68,14 +68,14 @@
   .skc-root-layout,
   .skc-root-layout > * {
     > .skc-split-layout > .skc-split-layout__content {
+      width: calc(100% - (12rem));
       max-width: 70.5rem;
       margin: 0 auto;
-      width: calc(100% - (12rem));
 
       > * {
-        padding-inline: 0;
         overflow-y: auto;
         height: calc(100vh - 12rem);
+        padding-inline: 0;
       }
 
       > :first-child {

--- a/packages/skcom-css/src/components/table-cell.scss
+++ b/packages/skcom-css/src/components/table-cell.scss
@@ -179,7 +179,7 @@
 }
 
 // Options Menu
-.skc-table-cell .skc-menu {
+.skc-table-cell > .skc-menu {
   inset: 0 0 auto 0;
   width: 100%;
 }

--- a/packages/skcom-css/src/components/table-cell.scss
+++ b/packages/skcom-css/src/components/table-cell.scss
@@ -17,16 +17,20 @@
 
   // Cell borders
 
+  // Horizontal borders:
+  // All cells that is not the rightmost gets a right border
   &:not(:last-child) {
     border-right: 1px solid var(--outline-variant);
   }
 
+  // Vertical borders:
+  // All rows that is not the last gets a bottom border
   .skc-table-row:not(:last-child) &,
+  // The last row in the head area succeeded by a body area gets a bottom border
   .skc-table:has(.skc-table-body) .skc-table-head .skc-table-row:last-child &,
-  .skc-data-table__content:has(.skc-table-body)
-    .skc-table-head
-    .skc-table-row:last-child
-    &,
+  .skc-data-table-content:has(.skc-table-body) .skc-table-head .skc-table-row:last-child
+  &,
+  // The last row in the body area succeeded by a foot area gets a bottom border
   .skc-table:has(.skc-table-foot) .skc-table-body .skc-table-row:last-child & {
     border-bottom: 1px solid var(--outline-variant);
   }

--- a/packages/skcom-react/src/components/DataTable/index.tsx
+++ b/packages/skcom-react/src/components/DataTable/index.tsx
@@ -46,7 +46,7 @@ export function DataTable({ children, style, className }: DataTableProps) {
     <motion.figure
       layout
       transition={transition(duration.medium4, easing.standard)}
-      style={style}
+      style={{ ...style, borderRadius: 20 }}
       className={cn(["skc-data-table", className])}
     >
       {children}

--- a/packages/skcom-react/src/components/DataTableHead/index.tsx
+++ b/packages/skcom-react/src/components/DataTableHead/index.tsx
@@ -10,9 +10,6 @@ import { TableRow } from "../TableRow";
 // Types
 import { DataTableColumnDef, SKComponent } from "../../types";
 
-// Styles
-import "@suankularb-components/css/dist/css/components/table-head.css";
-
 // Utilities
 import {
   transition,

--- a/packages/skcom-react/src/components/Dialog/index.tsx
+++ b/packages/skcom-react/src/components/Dialog/index.tsx
@@ -161,7 +161,7 @@ export function Dialog({
               ),
             }}
             transition={transition(duration.medium2, easing.standardDecelerate)}
-            style={{ ...style, width }}
+            style={{ ...style, width, borderRadius: 28 }}
             className={cn(["skc-dialog", className])}
           >
             {children}

--- a/packages/skcom-react/src/components/FAB/index.tsx
+++ b/packages/skcom-react/src/components/FAB/index.tsx
@@ -170,17 +170,20 @@ export function FAB({
     title: tooltip,
     className: "skc-fab__wrapper",
     ...rippleListeners,
-  } satisfies JSX.IntrinsicElements["a" | "button"];
+  } satisfies React.ComponentProps<"a" | "button">;
 
   const content = (
     <AnimatePresence initial={false}>
       {
         // Hide the FAB on scroll if `stateOnScroll` set to `disappear`
-        !(stateOnScroll === "disappear" && scrollDir === "down") && (
+        !(
+          atBreakpoint === "base" &&
+          stateOnScroll === "disappear" &&
+          scrollDir === "down"
+        ) && (
           <motion.div
             ref={fabRef}
             layout
-            layoutRoot
             initial={{ scale: 0.4, x: 20, y: 20, opacity: 0 }}
             animate={{ scale: 1, x: 0, y: 0, opacity: 1 }}
             exit={{
@@ -203,13 +206,13 @@ export function FAB({
                 ? "skc-fab--primary"
                 : color === "secondary"
                 ? "skc-fab--secondary"
-                : color === "tertiary"
-                ? "skc-fab--tertiary"
-                : undefined,
-              size === "small"
-                ? "skc-fab--small"
-                : size === "large"
-                ? "skc-fab--large"
+                : color === "tertiary" && "skc-fab--tertiary",
+              // Only apply size on mobile (the other sizes don’t fit in the
+              // Navigation Rail)
+              atBreakpoint === "base"
+                ? size === "small"
+                  ? "skc-fab--small"
+                  : size === "large" && "skc-fab--large"
                 : "skc-fab--standard",
               className,
             ])}
@@ -220,31 +223,32 @@ export function FAB({
               </motion.div>
             )}
             <AnimatePresence initial={false}>
-              {
+              {children &&
+                // Only show the label on mobile (the label doesn’t fit in the
+                // Navigation Rail)
+                atBreakpoint === "base" &&
                 // Hide the label on scroll if `stateOnScroll` set to `minimize`
-                !(stateOnScroll === "minimize" && scrollDir === "down") &&
-                  children && (
-                    <motion.span
-                      layout="position"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{
-                        opacity: 0,
-                        transition: transition(
-                          duration.short2,
-                          easing.standardAccelerate
-                        ),
-                      }}
-                      transition={transition(
-                        duration.medium1,
-                        easing.standardDecelerate
-                      )}
-                      className="skc-fab__label"
-                    >
-                      {children}
-                    </motion.span>
-                  )
-              }
+                !(stateOnScroll === "minimize" && scrollDir === "down") && (
+                  <motion.span
+                    layout="position"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{
+                      opacity: 0,
+                      transition: transition(
+                        duration.short2,
+                        easing.standardAccelerate
+                      ),
+                    }}
+                    transition={transition(
+                      duration.medium1,
+                      easing.standardDecelerate
+                    )}
+                    className="skc-fab__label"
+                  >
+                    {children}
+                  </motion.span>
+                )}
             </AnimatePresence>
             <motion.span
               aria-hidden

--- a/packages/skcom-react/src/components/FAB/index.tsx
+++ b/packages/skcom-react/src/components/FAB/index.tsx
@@ -15,7 +15,7 @@ import {
   useRipple,
 } from "../../utils/animation";
 import { cn } from "../../utils/className";
-import { useScrollDirection } from "../../utils/window";
+import { useBreakpoint, useScrollDirection } from "../../utils/window";
 
 /**
  * Props for {@link FAB}.
@@ -162,7 +162,8 @@ export function FAB({
   const { rippleListeners, rippleControls, rippleStyle } = useRipple(fabRef);
 
   // Scroll direction
-  const scrollDir = useScrollDirection();
+  const { atBreakpoint } = useBreakpoint();
+  const scrollDir = useScrollDirection({ disabled: atBreakpoint !== "base" });
 
   const props = {
     "aria-label": alt,
@@ -179,6 +180,7 @@ export function FAB({
           <motion.div
             ref={fabRef}
             layout
+            layoutRoot
             initial={{ scale: 0.4, x: 20, y: 20, opacity: 0 }}
             animate={{ scale: 1, x: 0, y: 0, opacity: 1 }}
             exit={{

--- a/packages/skcom-react/src/components/FAB/index.tsx
+++ b/packages/skcom-react/src/components/FAB/index.tsx
@@ -197,7 +197,12 @@ export function FAB({
               ),
             }}
             transition={transition(duration.medium1, easing.standardDecelerate)}
-            style={style}
+            style={{
+              ...style,
+              borderRadius: { small: 12, standard: 16, large: 28 }[
+                (atBreakpoint === "base" && size) || "standard"
+              ],
+            }}
             className={cn([
               "skc-fab",
               color === "surface"

--- a/packages/skcom-react/src/components/FullscreenDialog/index.tsx
+++ b/packages/skcom-react/src/components/FullscreenDialog/index.tsx
@@ -132,7 +132,7 @@ export function FullscreenDialog({
 
   const fullscreenDialogAnimation: Variants = {
     initial: { opacity: 0, scale: 0.75 },
-    animate: { opacity: 1, scale: 1 },
+    animate: { opacity: 1, scale: 1, x: 0, y: 0 },
     exit: {
       opacity: 0,
       scale: 0.9,
@@ -212,18 +212,13 @@ export function FullscreenDialog({
             aria-labelledby={`${dialogID}-title`}
             aria-describedby={`${dialogID}-desc`}
             aria-modal="true"
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            variants={
-              atBreakpoint === "base"
-                ? fullscreenDialogAnimation
-                : dialogAnimation
-            }
+            {...(atBreakpoint === "base"
+              ? fullscreenDialogAnimation
+              : dialogAnimation)}
             transition={transition(duration.medium2, easing.standardDecelerate)}
             style={{
               ...style,
-              width: atBreakpoint === "base" ? undefined : width,
+              ...(atBreakpoint !== "base" ? { width, borderRadius: 28 } : {}),
             }}
             className={cn(["skc-fullscreen-dialog", className])}
           >
@@ -240,9 +235,9 @@ export function FullscreenDialog({
             </div>
 
             {/* Content */}
-            <motion.div className="skc-fullscreen-dialog__content">
+            <div className="skc-fullscreen-dialog__content">
               {injectedChildren}
-            </motion.div>
+            </div>
           </motion.div>
         </>
       )}

--- a/packages/skcom-react/src/components/NavBar/index.tsx
+++ b/packages/skcom-react/src/components/NavBar/index.tsx
@@ -121,34 +121,28 @@ export function NavBar({
   });
 
   return (
-    <motion.nav
-      layoutRoot
-      style={style}
-      className={cn(["skc-nav-bar", className])}
-    >
-      <div className="skc-nav-bar__main">
-        <LayoutGroup>
-          <section className="skc-nav-bar__toggle-and-fab">
-            <Button
-              appearance="text"
-              icon={<MaterialIcon icon="menu" />}
-              alt={locale === "th" ? "เปิดเมนู" : "Toggle Navigation Drawer"}
-              onClick={onNavToggle}
-            />
-            <div className="skc-nav-bar__brand">{brand}</div>
-            {responsiveFab}
-          </section>
-          <motion.section
-            layout="position"
-            transition={transition(duration.medium2, easing.standard)}
-            className="skc-nav-bar__destinations"
-          >
-            {children}
-          </motion.section>
-        </LayoutGroup>
-      </div>
+    <nav style={style} className={cn(["skc-nav-bar", className])}>
+      <motion.div layout layoutRoot className="skc-nav-bar__main">
+        <section className="skc-nav-bar__toggle-and-fab">
+          <Button
+            appearance="text"
+            icon={<MaterialIcon icon="menu" />}
+            alt={locale === "th" ? "เปิดเมนู" : "Toggle Navigation Drawer"}
+            onClick={onNavToggle}
+          />
+          <div className="skc-nav-bar__brand">{brand}</div>
+          {responsiveFab}
+        </section>
+        <motion.section
+          layout="position"
+          transition={transition(duration.medium2, easing.standard)}
+          className="skc-nav-bar__destinations"
+        >
+          {children}
+        </motion.section>
+      </motion.div>
       <section className="skc-nav-bar__end">{end}</section>
-    </motion.nav>
+    </nav>
   );
 }
 

--- a/packages/skcom-react/src/components/NavBar/index.tsx
+++ b/packages/skcom-react/src/components/NavBar/index.tsx
@@ -98,28 +98,6 @@ export function NavBar({
 }: NavBarProps) {
   const { duration, easing } = useAnimationConfig();
 
-  const { atBreakpoint } = useBreakpoint();
-  const responsiveFab = React.Children.map(fab, (child) => {
-    if (matchDisplayName(child, "FAB"))
-      // (@SiravitPhokeed)
-      // We’re not conditionally cloning the FAB (but instead just changing the
-      // props on the same cloned component) because apparently having the
-      // Navigation Rail version be technically a different component from the
-      // Navigation Bar one confuses Framer Motion and creates a weird layout
-      // shift effect.
-      return React.cloneElement(
-        child as JSX.Element,
-        atBreakpoint !== "base"
-          ? {
-              children: undefined,
-              size: "standard",
-              stateOnScroll: undefined,
-            }
-          : undefined
-      );
-    return child;
-  });
-
   return (
     <nav style={style} className={cn(["skc-nav-bar", className])}>
       <motion.div layout layoutRoot className="skc-nav-bar__main">
@@ -131,7 +109,7 @@ export function NavBar({
             onClick={onNavToggle}
           />
           <div className="skc-nav-bar__brand">{brand}</div>
-          {responsiveFab}
+          {fab}
         </section>
         <motion.section
           layout="position"

--- a/packages/skcom-react/src/types.ts
+++ b/packages/skcom-react/src/types.ts
@@ -49,6 +49,26 @@ export type DataTableColumnDef<T = any> = ColumnDef<T> &
     render: (row: T) => string | JSX.Element | null;
 
     /**
+     * The render function used when a cell in this column is being edited.
+     * Enables editing if defined.
+     *
+     * @param row The data passed in for each row.
+     * @returns A JSX Element, usually a Text Field or a Chip Field.
+     *
+     * @todo
+     */
+    editingField?: (row: T) => JSX.Element;
+
+    /**
+     * Triggers when the user is don editing a cell in this column.
+     *
+     * @param value
+     *
+     * @todo
+     */
+    onSubmitEdit?: (value: any) => any;
+
+    /**
      * The message shown when there is no data for a Table Cell.
      */
     noDataMsg: string | JSX.Element;

--- a/packages/skcom-react/src/utils/window.ts
+++ b/packages/skcom-react/src/utils/window.ts
@@ -3,12 +3,22 @@ import React from "react";
 
 /**
  * Watches user scrolls for a change in direction.
+ *
+ * @param options Options for this hook.
+ * @param options.disabled Disable the check, always return up.
+ *
  * @returns The direction the user is scrolling.
  */
-export function useScrollDirection() {
+export function useScrollDirection(options?: Partial<{ disabled: boolean }>) {
   const [direction, setDirection] = React.useState<"up" | "down">("up");
 
   React.useEffect(() => {
+    // Don’t perform the check if the hook is disabled
+    if (options?.disabled) {
+      setDirection("up");
+      return;
+    }
+
     let lastScrollY = window.scrollY;
 
     const handleScroll = () => {
@@ -24,7 +34,7 @@ export function useScrollDirection() {
     // Set/clear event listeners
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [options?.disabled]);
 
   return direction;
 }


### PR DESCRIPTION
**Fixes**
- Many selectors are too wide and can accidentally override a Dialog’s content:
  - In Chip Field
  - In FAB
  - In Navigation Rail
  - In Table Cell
- Dialog layering is broken again
- Dialog is off-center after hitting a new breakpoint
- Navigation Drawer appears behind its Scrim
- Contextual adaptations applied on other similar components not applied to Select
- Some rounded corners are warped during transitions
- Contact Card opens links in the same tab