### PR TITLE
Release 3.2.1

### DIFF
--- a/apps/demo/pages/components/input.tsx
+++ b/apps/demo/pages/components/input.tsx
@@ -70,6 +70,7 @@ const ChipFieldSection: FC = () => {
       <Header>Chip Field</Header>
       <ChipField
         label="Classes learning this subject"
+        helperMsg="Comma-separated list"
         value={value}
         onChange={setValue}
         onNewEntry={(value) => {

--- a/packages/skcom-css/src/components/app-drawer.scss
+++ b/packages/skcom-css/src/components/app-drawer.scss
@@ -26,3 +26,7 @@
 .skc-app-drawer__toggle {
   z-index: 85;
 }
+
+.skc-app-drawer__anchor {
+  position: relative;
+}

--- a/packages/skcom-css/src/components/chip-field.scss
+++ b/packages/skcom-css/src/components/chip-field.scss
@@ -136,6 +136,15 @@
   }
 }
 
+// Helper message
+.skc-chip-field__helper-msg {
+  @include type.font("body-small");
+  position: absolute;
+  inset: auto 0 -2.25rem 1rem;
+  height: 2rem;
+  color: var(--on-surface-variant);
+}
+
 @include mix.breakpoint("sm") {
   .skc-section > .skc-chip-field:focus-within {
     margin-inline: -1px;

--- a/packages/skcom-css/src/components/page-header.scss
+++ b/packages/skcom-css/src/components/page-header.scss
@@ -14,6 +14,10 @@
 .skc-page-header {
   @extend .skc-content-layout;
   padding-block: 1rem 0.5rem;
+
+  .skc-app-drawer__toggle {
+    white-space: nowrap;
+  }
 }
 
 .skc-page-header__blobs {
@@ -74,7 +78,10 @@
 }
 
 .skc-page-header__text {
+  overflow: hidden;
   flex-grow: 1;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 @include mix.breakpoint("sm") {

--- a/packages/skcom-css/src/components/snackbar.scss
+++ b/packages/skcom-css/src/components/snackbar.scss
@@ -35,7 +35,7 @@
   .skc-root-layout > &,
   .skc-root-layout > * > & {
     position: fixed;
-    z-index: 90;
+    z-index: 95;
   }
 
   .skc-nav-bar ~ aside & {

--- a/packages/skcom-react/src/components/AppDrawer/index.tsx
+++ b/packages/skcom-react/src/components/AppDrawer/index.tsx
@@ -55,7 +55,7 @@ export function AppDrawer({
   const { duration, easing } = useAnimationConfig();
 
   return (
-    <div className="relative">
+    <div className="skc-app-drawer__anchor">
       {/* Toggle */}
       <Button
         appearance="text"

--- a/packages/skcom-react/src/components/ChipField/index.tsx
+++ b/packages/skcom-react/src/components/ChipField/index.tsx
@@ -47,6 +47,13 @@ export interface ChipFieldProps extends SKComponent {
   alt?: string;
 
   /**
+   * A short description of the Chip Field.
+   *
+   * - Optional.
+   */
+  helperMsg?: string | JSX.Element;
+
+  /**
    * The value inside the field that is used to create Input Chips. This is
    * useful if you want a controlled input.
    *
@@ -140,6 +147,7 @@ export interface ChipFieldProps extends SKComponent {
  * @param children The Input Chips that the user have already entered.
  * @param label The placeholder text (if no placeholder specified or when not focused and no value) and the label text (when focused or has value).
  * @param alt A description of the Chip Field for screen readers, similar to `alt` on `<img>`.
+ * @param helperMsg A short description of the Chip Field.
  * @param value The value inside the field that is used to create Input Chips. This is useful if you want a controlled input.
  * @param onChange This function triggers when the user makes changes to the field value. The value is passed in via the function.
  * @param onNewEntry This function triggers when the user hits the spacebar while in the field.
@@ -155,6 +163,7 @@ export function ChipField({
   children,
   label,
   alt,
+  helperMsg,
   value,
   onChange,
   onNewEntry,
@@ -371,6 +380,13 @@ export function ChipField({
         value={typeof loading === "number" ? loading : undefined}
         visible={typeof loading === "number" || loading}
       />
+
+      {/* Helper/error message */}
+      {helperMsg && (
+        <span id={`${fieldID}-helper`} className="skc-chip-field__helper-msg">
+          {helperMsg}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/skcom-react/src/components/ListItemContent/index.tsx
+++ b/packages/skcom-react/src/components/ListItemContent/index.tsx
@@ -68,7 +68,7 @@ export function ListItemContent({
   const Element = element || "div";
 
   return (
-    <Element style={style} className={cn(["skc-list-item", className])}>
+    <Element style={style} className={cn(["skc-list-item-content", className])}>
       {/* Overline */}
       {overline && (
         <span className="skc-list-item-content__overline">{overline}</span>


### PR DESCRIPTION
**Features**
- Helper message support on Chip Field

**Fixes**
- App Drawer position relies on the Tailwind CSS utility class `relative`
- List Item Content erroneously references the class name of List Item
- Snackbar appears behind Dialog and Full-screen Dialog
- Page Header text is now truncated
- App Drawer toggle text in Page Header breaks on smaller screens