### PR TITLE
Release 3.2.2 (Hotfix)

### DIFF
--- a/packages/skcom-react/src/components/TextField/index.tsx
+++ b/packages/skcom-react/src/components/TextField/index.tsx
@@ -390,15 +390,21 @@ export function TextField<Value extends string | File>({
             setError(Boolean(incError || (required && !value)));
           },
           onChange: (
-            e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+            event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
           ) => {
-            if (inputAttr?.type === "file")
-              setFile(
-                (e.target as HTMLInputElement).files?.length
-                  ? (e.target as HTMLInputElement).files![0]
-                  : null
-              );
-            if (onChange) onChange((file || e.target.value) as Value);
+            const { files, value } = event.target as HTMLInputElement;
+
+            // Handle file input if type is `file`
+            if (inputAttr?.type === "file") {
+              if (files?.length) {
+                setFile(files[0]);
+                onChange?.(files[0] as Value);
+              } else setFile(null);
+              return;
+            }
+
+            // Otherwise, treat value as text
+            onChange?.(value as Value);
 
             if (value === undefined) expandTextarea();
           },


### PR DESCRIPTION
**Fixes**
- Text Field with `type` set to `file` via `inputAttr` erroneously sends the pathname as a string to `onChange` instead of the File object